### PR TITLE
Fix resolver version warning and clippy warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["field", "maybe_rayon", "plonky2", "starky", "util"]
+resolver = "2"
 
 [profile.release]
 opt-level = 3

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -136,7 +136,7 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     // obtaining our duplex's post-state which contains the PoW response.
     let mut duplex_intermediate_state = challenger.sponge_state;
     let witness_input_pos = challenger.input_buffer.len();
-    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone().into_iter(), 0);
+    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone(), 0);
 
     let pow_witness = (0..=F::NEG_ONE.to_canonical_u64())
         .into_par_iter()

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -36,6 +36,7 @@ impl SelectorsInfo {
 ///         k
 ///     else
 ///         UNUSED_SELECTOR
+#[allow(clippy::single_range_in_vec_init)]
 pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>(
     gates: &[GateRef<F, D>],
     instances: &[GateInstance<F, D>],

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -332,8 +332,8 @@ mod tests {
 
         // These are mostly arbitrary, but we want to test some rounds with enough inputs/outputs to
         // trigger multiple absorptions/squeezes.
-        let num_inputs_per_round = vec![2, 5, 3];
-        let num_outputs_per_round = vec![1, 2, 4];
+        let num_inputs_per_round = [2, 5, 3];
+        let num_outputs_per_round = [1, 2, 4];
 
         // Generate random input messages.
         let inputs_per_round: Vec<Vec<F>> = num_inputs_per_round


### PR DESCRIPTION
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest```

Also make clippy happy.