### PR TITLE
Revert "Update itertools requirement from 0.10.0 to 0.11.0"

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.10.0", default-features = false, features = ["use_alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "rand"] }
 plonky2_util = { version = "0.1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -21,8 +21,8 @@ timing = ["std"]
 ahash = { version = "0.8.3", default-features = false, features = ["compile-time-rng"] } # NOTE: Be sure to keep this version the same as the dependency in `hashbrown`.
 anyhow = { version = "1.0.40", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false, features = ["ahash", "serde"] } # NOTE: When upgrading, see `ahash` dependency.
-itertools = { version = "0.11.0", default-features = false }
 keccak-hash = { version = "0.10.0", default-features = false }
+itertools = { version = "0.10.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
 num = { version = "0.4", default-features = false, features = ["rand"] }

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -18,7 +18,7 @@ timing = ["plonky2/timing"]
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
-itertools = { version = "0.11.0", default-features = false }
+itertools = { version = "0.10.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
 plonky2 = { version = "0.1.2", default-features = false }


### PR DESCRIPTION
This reverts commit e072883e05f7d9631d97cc98dba4186644746585.

We're still relying on the official plonky2 crate while using our own starky crate.