### PR TITLE
fix: indexing off-by-one error with proving

### DIFF
--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -18,10 +18,6 @@ use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer
 use crate::permutation::PermutationPair;
 use crate::vars::{StarkEvaluationTargets, StarkEvaluationVars};
 
-const TRACE_ORACLE_INDEX: usize = 0;
-const PERMUTATION_CTL_ORACLE_INDEX: usize = 1;
-const QUOTIENT_ORACLE_INDEX: usize = 2;
-
 pub struct LookupConfig {
     pub degree_bits: usize,
     pub num_zs: usize,
@@ -102,31 +98,41 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
         config: &StarkConfig,
         lookup_cfg: Option<&LookupConfig>,
     ) -> FriInstanceInfo<F, D> {
-        let trace_info = FriPolynomialInfo::from_range(TRACE_ORACLE_INDEX, 0..Self::COLUMNS);
+        let mut oracles = vec![];
+        let trace_info = FriPolynomialInfo::from_range(oracles.len(), 0..Self::COLUMNS);
         let trace_oracle = FriOracleInfo {
             num_polys: Self::COLUMNS,
             blinding: false,
         };
+        oracles.push(trace_oracle);
 
         let num_ctl_zs = lookup_cfg.map(|n| n.num_zs).unwrap_or_default();
         let num_permutation_batches = self.num_permutation_batches(config);
         let num_z_polys = num_permutation_batches + num_ctl_zs;
 
-        let permutation_zs_info =
-            FriPolynomialInfo::from_range(PERMUTATION_CTL_ORACLE_INDEX, 0..num_z_polys);
+        let permutation_zs_info = FriPolynomialInfo::from_range(oracles.len(), 0..num_z_polys);
+
+        let ctl_zs_info = FriPolynomialInfo::from_range(
+            oracles.len(),
+            num_permutation_batches..num_permutation_batches + num_ctl_zs,
+        );
 
         let permutation_oracle = FriOracleInfo {
             num_polys: num_z_polys,
             blinding: false,
         };
 
+        if lookup_cfg.is_some() {
+            oracles.push(permutation_oracle);
+        }
+
         let num_quotient_polys = self.quotient_degree_factor() * config.num_challenges;
-        let quotient_info =
-            FriPolynomialInfo::from_range(QUOTIENT_ORACLE_INDEX, 0..num_quotient_polys);
+        let quotient_info = FriPolynomialInfo::from_range(oracles.len(), 0..num_quotient_polys);
         let quotient_oracle = FriOracleInfo {
             num_polys: num_quotient_polys,
             blinding: false,
         };
+        oracles.push(quotient_oracle);
 
         let zeta_batch = FriBatchInfo {
             point: zeta,
@@ -144,11 +150,6 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
         let mut batches = vec![zeta_batch, zeta_next_batch];
 
         if let Some(lookup_cfg) = lookup_cfg {
-            let ctl_zs_info = FriPolynomialInfo::from_range(
-                PERMUTATION_CTL_ORACLE_INDEX,
-                num_permutation_batches..num_permutation_batches + num_ctl_zs,
-            );
-
             let ctl_last_batch = FriBatchInfo {
                 point: F::Extension::primitive_root_of_unity(lookup_cfg.degree_bits).inverse(),
                 polynomials: ctl_zs_info,
@@ -157,10 +158,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
             batches.push(ctl_last_batch);
         }
 
-        FriInstanceInfo {
-            oracles: vec![trace_oracle, permutation_oracle, quotient_oracle],
-            batches,
-        }
+        FriInstanceInfo { oracles, batches }
     }
 
     /// Computes the FRI instance used to prove this Stark.

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -122,7 +122,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
             blinding: false,
         };
 
-        if lookup_cfg.is_some() {
+        if self.uses_permutation_args() || lookup_cfg.is_some() {
             oracles.push(permutation_oracle);
         }
 


### PR DESCRIPTION
Indexing when getting the fri instance works differently for proving with/without lookups - This PR fixes a bug with proving without lookups in the original implementation.