### PR TITLE
Support constraint degree of zero

### DIFF
--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -86,7 +86,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
 
     /// The maximum constraint degree.
     fn quotient_degree_factor(&self) -> usize {
-        1.max(self.constraint_degree() - 1)
+        2.max(self.constraint_degree()) - 1
     }
 
     fn num_quotient_polys(&self, config: &StarkConfig) -> usize {


### PR DESCRIPTION
We re-arrange our arithmetic to avoid a subtraction of unsigned integers going below zero.