### PR TITLE
Simple location information for violated constraints

### DIFF
--- a/starky/src/constraint_consumer.rs
+++ b/starky/src/constraint_consumer.rs
@@ -69,7 +69,7 @@ impl<P: PackedField> ConstraintConsumer<P> {
         #[cfg(feature = "std")]
         if self.debug_api && !constraint.is_zeros() {
             log::error!(
-                "ConstraintConsumer - DEBUG trace (non-zero-constraint): {:?}",
+                "ConstraintConsumer - DEBUG trace (non-zero-constraint): {}",
                 std::panic::Location::caller()
             );
         }


### PR DESCRIPTION
No need for debug-pretty printing.