### PR TITLE
feat: add `is_nonzero`

### DIFF
--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -381,9 +381,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         // if x is zero, result should be `0`, otherwise result should be `1`
         let result = self.mul(x, inv);
 
-        // Enforce the result through arithmetic        
-        let tmp = self.sub(result, one);        // (x * inv - 1)
-        let tmp = self.mul(tmp, x);             // (x * inv - 1) * x
+        // Enforce the result through arithmetic
+        let tmp = self.sub(result, one); // (x * inv - 1)
+        let tmp = self.mul(tmp, x); // (x * inv - 1) * x
 
         // If everything has been done correctly, `(x * inv - 1) * x` will always equal 0
         // this is because either `x * inv` equals `1`, making `(x * inv - 1)` equal `0`

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -9,7 +9,7 @@ use crate::field::extension::Extendable;
 use crate::field::types::Field;
 use crate::hash::hash_types::RichField;
 use crate::iop::ext_target::ExtensionTarget;
-use crate::iop::target::Target;
+use crate::iop::target::{BoolTarget, Target};
 use crate::iop::wire::Wire;
 use crate::iop::witness::{PartialWitness, PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_data::{CommonCircuitData, ProverOnlyCircuitData};
@@ -331,7 +331,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Ran
 #[derive(Debug, Default)]
 pub struct NonzeroTestGenerator {
     pub(crate) to_test: Target,
-    pub(crate) dummy: Target,
+    pub(crate) result: BoolTarget,
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for NonzeroTestGenerator {
@@ -345,25 +345,18 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Non
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let to_test_value = witness.get_target(self.to_test);
-
-        let dummy_value = if to_test_value == F::ZERO {
-            F::ONE
-        } else {
-            to_test_value.inverse()
-        };
-
-        out_buffer.set_target(self.dummy, dummy_value);
+        out_buffer.set_bool_target(self.result, to_test_value.is_nonzero());
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
         dst.write_target(self.to_test)?;
-        dst.write_target(self.dummy)
+        dst.write_target_bool(self.result)
     }
 
     fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let to_test = src.read_target()?;
-        let dummy = src.read_target()?;
-        Ok(Self { to_test, dummy })
+        let result = src.read_target_bool()?;
+        Ok(Self { to_test, result })
     }
 }
 

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -345,7 +345,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Non
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let to_test_value = witness.get_target(self.to_test);
-        
+
         let inv_value = if to_test_value.is_zero() {
             F::ONE
         } else {
@@ -363,7 +363,10 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Non
     fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let to_test = src.read_target()?;
         let dummy = src.read_target()?;
-        Ok(Self { to_test, inv: dummy })
+        Ok(Self {
+            to_test,
+            inv: dummy,
+        })
     }
 }
 


### PR DESCRIPTION
Uses division by self to constrain the resulting value.

(uses illegal divide by zero to constrain one side and `x/(x+1) != 1` to constrain the other)