### PR TITLE
Fix cargo warning about profiles

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -88,12 +88,6 @@ harness = false
 name = "reverse_index_bits"
 harness = false
 
-[profile.release]
-incremental = true
-lto = "fat"
-debug = true
-opt-level=3
-
 # Display math equations properly in documentation
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]


### PR DESCRIPTION
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/matthias/mozak/prog/plonky2/plonky2/Cargo.toml
workspace: /Users/matthias/mozak/prog/plonky2/Cargo.toml
```