### PR TITLE
refactor: switch to `tiny-keccak` library

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -23,7 +23,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-keccak-hash = { version = "0.10.0", default-features = false }
+tiny-keccak = { version = "2.0", features = ["keccak"] }
 log = { workspace = true }
 num = { workspace = true }
 rand = { workspace = true }

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -7,7 +7,6 @@ use alloc::{
 };
 
 use itertools::Itertools;
-use keccak_hash::keccak;
 
 use super::lookup_table::LookupTable;
 use crate::field::extension::Extendable;
@@ -16,6 +15,7 @@ use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
+use crate::hash::keccak::keccak;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGeneratorRef};
 use crate::iop::target::Target;

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -10,7 +10,6 @@ use alloc::{
 use std::sync::Arc;
 
 use itertools::Itertools;
-use keccak_hash::keccak;
 use plonky2_util::ceil_div_usize;
 
 use crate::field::extension::Extendable;
@@ -19,6 +18,7 @@ use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
+use crate::hash::keccak::keccak;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGeneratorRef};
 use crate::iop::target::Target;

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -3,12 +3,11 @@ use alloc::{vec, vec::Vec};
 use core::mem::size_of;
 
 use itertools::Itertools;
-use keccak_hash::keccak;
+use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
 use crate::hash::hash_types::{BytesHash, RichField};
 use crate::hash::hashing::PlonkyPermutation;
 use crate::plonk::config::Hasher;
-use crate::util::serialization::Write;
 
 pub const SPONGE_RATE: usize = 8;
 pub const SPONGE_CAPACITY: usize = 4;
@@ -68,7 +67,7 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation<F> {
         }
 
         let hash_onion = core::iter::repeat_with(|| {
-            let output = keccak(state_bytes.clone()).to_fixed_bytes();
+            let output = keccak(state_bytes.clone()).0;
             state_bytes = output.to_vec();
             output
         });
@@ -107,20 +106,39 @@ impl<F: RichField, const N: usize> Hasher<F> for KeccakHash<N> {
     type Permutation = KeccakPermutation<F>;
 
     fn hash_no_pad(input: &[F]) -> Self::Hash {
-        let mut buffer = Vec::with_capacity(input.len());
-        buffer.write_field_vec(input).unwrap();
+        let mut keccak256 = Keccak::v256();
+        for x in input.iter() {
+            let b = x.to_canonical_u64().to_le_bytes();
+            keccak256.update(&b);
+        }
+        let mut hash_bytes = [0u8; 32];
+        keccak256.finalize(&mut hash_bytes);
+
         let mut arr = [0; N];
-        let hash_bytes = keccak(buffer).0;
         arr.copy_from_slice(&hash_bytes[..N]);
         BytesHash(arr)
     }
 
     fn two_to_one(left: Self::Hash, right: Self::Hash) -> Self::Hash {
-        let mut v = vec![0; N * 2];
-        v[0..N].copy_from_slice(&left.0);
-        v[N..].copy_from_slice(&right.0);
+        let mut keccak256 = Keccak::v256();
+        keccak256.update(&left.0);
+        keccak256.update(&right.0);
+
+        let mut hash_bytes = [0u8; 32];
+        keccak256.finalize(&mut hash_bytes);
+
         let mut arr = [0; N];
-        arr.copy_from_slice(&keccak(v).0[..N]);
+        arr.copy_from_slice(&hash_bytes[..N]);
         BytesHash(arr)
     }
+}
+
+pub fn keccak<T: AsRef<[u8]>>(s: T) -> BytesHash<32> {
+    let mut keccak256 = Keccak::v256();
+    keccak256.update(s.as_ref());
+
+    let mut hash_bytes = [0u8; 32];
+    keccak256.finalize(&mut hash_bytes);
+
+    BytesHash(hash_bytes)
 }


### PR DESCRIPTION
Split off from #82.

This enables incremental hashing without allocation (aka `collect`)