### PR TITLE
fix: remove trivial allocations and `try_into`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ ahash = { version = "0.8.9", default-features = false, features = ["compile-time
 anyhow = { version = "1.0.80", default-features = false }
 hashbrown = { version = "0.14.3", default-features = false, features = ["ahash", "serde"] } # NOTE: When upgrading, see `ahash` dependency.
 itertools = { version = "0.12.1", default-features = false }
+iter_fixed = { version = "0.3.1", default-features = false }
 log = { version = "0.4.20", default-features = false }
 num = { version = "0.4", default-features = false, features = ["rand"] }
 rand = { version = "0.8.5", default-features = false }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -140,7 +140,7 @@ where
     F: Extendable<D>,
 {
     debug_assert_eq!(l.len() % D, 0);
-    l.chunks_exact(D)
-        .map(|c| F::Extension::from_basefield_array(c.to_vec().try_into().unwrap()))
+    l.array_chunks::<D>()
+        .map(|c| F::Extension::from_basefield_array(*c))
         .collect()
 }

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![feature(specialization)]
+#![feature(array_chunks)]
 #![cfg_attr(not(test), no_std)]
 #![cfg(not(test))]
 extern crate alloc;

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
@@ -118,14 +117,10 @@ impl Field for Secp256K1Base {
     }
 
     fn from_noncanonical_biguint(val: BigUint) -> Self {
-        Self(
-            val.to_u64_digits()
-                .into_iter()
-                .pad_using(4, |_| 0)
-                .collect::<Vec<_>>()[..]
-                .try_into()
-                .expect("error converting to u64 array"),
-        )
+        let mut vals = val.to_u64_digits().into_iter().pad_using(4, |_| 0);
+        Self(core::array::from_fn(|_| {
+            vals.next().expect("error converting to u64 array")
+        }))
     }
 
     #[inline]

--- a/field/src/secp256k1_scalar.rs
+++ b/field/src/secp256k1_scalar.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
@@ -126,14 +125,10 @@ impl Field for Secp256K1Scalar {
     }
 
     fn from_noncanonical_biguint(val: BigUint) -> Self {
-        Self(
-            val.to_u64_digits()
-                .into_iter()
-                .pad_using(4, |_| 0)
-                .collect::<Vec<_>>()[..]
-                .try_into()
-                .expect("error converting to u64 array"),
-        )
+        let mut vals = val.to_u64_digits().into_iter().pad_using(4, |_| 0);
+        Self(core::array::from_fn(|_| {
+            vals.next().expect("error converting to u64 array")
+        }))
     }
 
     #[inline]

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -37,10 +37,7 @@ pub trait Sample: Sized {
     /// Samples an array of values of length `N` using [`OsRng`].
     #[inline]
     fn rand_array<const N: usize>() -> [Self; N] {
-        Self::rand_vec(N)
-            .try_into()
-            .ok()
-            .expect("This conversion can never fail.")
+        core::array::from_fn(|_| Self::rand())
     }
 }
 
@@ -178,7 +175,7 @@ pub trait Field:
         let mut buf: Vec<Self> = Vec::with_capacity(n);
         // cumul_prod holds the last WIDTH elements of buf. This is redundant, but it's how we
         // convince LLVM to keep the values in the registers.
-        let mut cumul_prod: [Self; WIDTH] = x[..WIDTH].try_into().unwrap();
+        let mut cumul_prod: [Self; WIDTH] = *x.first_chunk().unwrap();
         buf.extend(cumul_prod);
         for (i, &xi) in x[WIDTH..].iter().enumerate() {
             cumul_prod[i % WIDTH] *= xi;

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -23,6 +23,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
+iter_fixed = { workspace = true }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 log = { workspace = true }
 num = { workspace = true }

--- a/plonky2/src/gadgets/random_access.rs
+++ b/plonky2/src/gadgets/random_access.rs
@@ -45,11 +45,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         access_index: Target,
         v: Vec<ExtensionTarget<D>>,
     ) -> ExtensionTarget<D> {
-        let selected: Vec<_> = (0..D)
-            .map(|i| self.random_access(access_index, v.iter().map(|et| et.0[i]).collect()))
-            .collect();
+        let selected = core::array::from_fn(|i| {
+            self.random_access(access_index, v.iter().map(|et| et.0[i]).collect())
+        });
 
-        ExtensionTarget(selected.try_into().unwrap())
+        ExtensionTarget(selected)
     }
 
     /// Like `random_access`, but with `HashOutTarget`s rather than simple `Target`s.

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -452,9 +452,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 
         let get_local_ext = |wire_range: Range<usize>| {
             debug_assert_eq!(wire_range.len(), D);
-            let values = wire_range.map(get_local_wire).collect::<Vec<_>>();
-            let arr = values.try_into().unwrap();
-            F::Extension::from_basefield_array(arr)
+            let mut values = wire_range.map(get_local_wire);
+            F::Extension::from_basefield_array(core::array::from_fn(|_| values.next().unwrap()))
         };
 
         let evaluation_point = get_local_ext(self.gate.wires_evaluation_point());

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -136,11 +136,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
-        let inputs: [_; SPONGE_WIDTH] = (0..SPONGE_WIDTH)
-            .map(|i| vars.get_local_ext_algebra(Self::wires_input(i)))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let inputs: [_; SPONGE_WIDTH] =
+            core::array::from_fn(|i| vars.get_local_ext_algebra(Self::wires_input(i)));
 
         let computed_outputs = Self::mds_layer_algebra(&inputs);
 
@@ -156,11 +153,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
         vars: EvaluationVarsBase<F>,
         mut yield_constr: StridedConstraintConsumer<F>,
     ) {
-        let inputs: [_; SPONGE_WIDTH] = (0..SPONGE_WIDTH)
-            .map(|i| vars.get_local_ext(Self::wires_input(i)))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let inputs: [_; SPONGE_WIDTH] =
+            core::array::from_fn(|i| vars.get_local_ext(Self::wires_input(i)));
 
         let computed_outputs = F::mds_layer_field(&inputs);
 
@@ -177,11 +171,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
     ) -> Vec<ExtensionTarget<D>> {
-        let inputs: [_; SPONGE_WIDTH] = (0..SPONGE_WIDTH)
-            .map(|i| vars.get_local_ext_algebra(Self::wires_input(i)))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let inputs: [_; SPONGE_WIDTH] =
+            core::array::from_fn(|i| vars.get_local_ext_algebra(Self::wires_input(i)));
 
         let computed_outputs = Self::mds_layer_algebra_circuit(builder, &inputs);
 
@@ -243,11 +234,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
         let get_local_ext =
             |wire_range| witness.get_extension_target(get_local_get_target(wire_range));
 
-        let inputs: [_; SPONGE_WIDTH] = (0..SPONGE_WIDTH)
-            .map(|i| get_local_ext(PoseidonMdsGate::<F, D>::wires_input(i)))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let inputs: [_; SPONGE_WIDTH] =
+            core::array::from_fn(|i| get_local_ext(PoseidonMdsGate::<F, D>::wires_input(i)));
 
         let outputs = F::mds_layer_field(&inputs);
 

--- a/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
+++ b/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
@@ -880,8 +880,8 @@ unsafe fn full_rounds(
     mut state: [u64; 12],
     round_constants: &[u64; WIDTH * HALF_N_FULL_ROUNDS],
 ) -> [u64; 12] {
-    for round_constants_chunk in round_constants.chunks_exact(WIDTH) {
-        state = full_round(state, round_constants_chunk.try_into().unwrap());
+    for round_constants_chunk in round_constants.array_chunks() {
+        state = full_round(state, *round_constants_chunk);
     }
     state
 }
@@ -901,8 +901,8 @@ unsafe fn partial_rounds(
             vcombine_u64(vcreate_u64(state[10]), vcreate_u64(state[11])),
         ],
     );
-    for round_constants_chunk in round_constants.chunks_exact(WIDTH) {
-        state = partial_round(state, round_constants_chunk.try_into().unwrap());
+    for round_constants_chunk in round_constants.array_chunks() {
+        state = partial_round(state, round_constants_chunk);
     }
     state.0
 }
@@ -922,7 +922,7 @@ fn wrap_state(state: [u64; 12]) -> [GoldilocksField; 12] {
 #[inline(always)]
 pub unsafe fn poseidon(state: [GoldilocksField; 12]) -> [GoldilocksField; 12] {
     let state = unwrap_state(state);
-    let state = const_layer_full(state, ALL_ROUND_CONSTANTS[0..WIDTH].try_into().unwrap());
+    let state = const_layer_full(state, ALL_ROUND_CONSTANTS.first_chunk().unwrap());
     let state = full_rounds(
         state,
         ALL_ROUND_CONSTANTS[WIDTH..WIDTH * (HALF_N_FULL_ROUNDS + 1)]

--- a/plonky2/src/hash/arch/x86_64/poseidon_goldilocks_avx2_bmi2.rs
+++ b/plonky2/src/hash/arch/x86_64/poseidon_goldilocks_avx2_bmi2.rs
@@ -940,7 +940,7 @@ pub unsafe fn poseidon(state: &[GoldilocksField; 12]) -> [GoldilocksField; 12] {
 
     // The first constant layer must be done explicitly. The remaining constant layers are fused
     // with the preceding MDS layer.
-    let state = const_layer(state, &ALL_ROUND_CONSTANTS[0..WIDTH].try_into().unwrap());
+    let state = const_layer(state, ALL_ROUND_CONSTANTS.first_chunk().unwrap());
 
     let state = half_full_rounds(state, 0);
     let state = all_partial_rounds(state, HALF_N_FULL_ROUNDS);
@@ -954,9 +954,7 @@ pub unsafe fn poseidon(state: &[GoldilocksField; 12]) -> [GoldilocksField; 12] {
 #[inline(always)]
 pub unsafe fn constant_layer(state_arr: &mut [GoldilocksField; WIDTH], round_ctr: usize) {
     let state = load_state(state_arr);
-    let round_consts = &ALL_ROUND_CONSTANTS[WIDTH * round_ctr..][..WIDTH]
-        .try_into()
-        .unwrap();
+    let round_consts = ALL_ROUND_CONSTANTS[WIDTH * round_ctr..].first_chunk().unwrap();
     let state = const_layer(state, round_consts);
     store_state(state_arr, state);
 }

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -91,14 +91,10 @@ impl<F: RichField> GenericHashOut<F> for HashOut<F> {
     }
 
     fn from_bytes(bytes: &[u8]) -> Self {
+        let bytes = bytes.as_chunks::<8>().0.first_chunk().unwrap();
+
         HashOut {
-            elements: bytes
-                .chunks(8)
-                .take(NUM_HASH_OUT_ELTS)
-                .map(|x| F::from_canonical_u64(u64::from_le_bytes(x.try_into().unwrap())))
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap(),
+            elements: bytes.map(u64::from_le_bytes).map(F::from_canonical_u64),
         }
     }
 

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -109,7 +109,7 @@ pub fn compress<F: Field, P: PlonkyPermutation<F>>(x: HashOut<F>, y: HashOut<F>)
     perm.permute();
 
     HashOut {
-        elements: perm.squeeze()[..NUM_HASH_OUT_ELTS].try_into().unwrap(),
+        elements: *perm.squeeze().first_chunk().unwrap(),
     }
 }
 

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -60,9 +60,10 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation<F> {
     }
 
     fn permute(&mut self) {
-        let mut state_bytes = vec![0u8; SPONGE_WIDTH * size_of::<u64>()];
+        const STRIDE: usize = size_of::<u64>();
+        let mut state_bytes = vec![0u8; SPONGE_WIDTH * STRIDE];
         for i in 0..SPONGE_WIDTH {
-            state_bytes[i * size_of::<u64>()..(i + 1) * size_of::<u64>()]
+            state_bytes[i * STRIDE..(i + 1) * STRIDE]
                 .copy_from_slice(&self.state[i].to_canonical_u64().to_le_bytes());
         }
 
@@ -74,22 +75,19 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation<F> {
 
         let hash_onion_u64s = hash_onion.flat_map(|output| {
             output
-                .chunks_exact(size_of::<u64>())
-                .map(|word| u64::from_le_bytes(word.try_into().unwrap()))
+                .array_chunks::<STRIDE>()
+                .copied()
+                .map(u64::from_le_bytes)
                 .collect_vec()
         });
 
         // Parse field elements from u64 stream, using rejection sampling such that words that don't
         // fit in F are ignored.
-        let hash_onion_elems = hash_onion_u64s
+        let mut hash_onion_elems = hash_onion_u64s
             .filter(|&word| word < F::ORDER)
             .map(F::from_canonical_u64);
 
-        self.state = hash_onion_elems
-            .take(SPONGE_WIDTH)
-            .collect_vec()
-            .try_into()
-            .unwrap();
+        self.state = core::array::from_fn(|_| hash_onion_elems.next().unwrap());
     }
 
     fn squeeze(&self) -> &[F] {

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -172,9 +172,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             // Ensure the rest of the state, if any, is zero:
             perm_inputs.set_from_iter(core::iter::repeat(zero), 2 * NUM_HASH_OUT_ELTS);
             let perm_outs = self.permute_swapped::<H>(perm_inputs, bit);
-            let hash_outs = perm_outs.squeeze()[0..NUM_HASH_OUT_ELTS]
-                .try_into()
-                .unwrap();
+            let hash_outs = *perm_outs.squeeze().first_chunk().unwrap();
             state = HashOutTarget {
                 elements: hash_outs,
             };

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -341,22 +341,12 @@ pub trait Poseidon: PrimeField64 {
                 let input_wire = PoseidonMdsGate::<Self, D>::wires_input(i);
                 builder.connect_extension(state[i], ExtensionTarget::from_range(index, input_wire));
             }
-            (0..SPONGE_WIDTH)
-                .map(|i| {
-                    let output_wire = PoseidonMdsGate::<Self, D>::wires_output(i);
-                    ExtensionTarget::from_range(index, output_wire)
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap()
+            core::array::from_fn(|i| {
+                let output_wire = PoseidonMdsGate::<Self, D>::wires_output(i);
+                ExtensionTarget::from_range(index, output_wire)
+            })
         } else {
-            let mut result = [builder.zero_extension(); SPONGE_WIDTH];
-
-            for r in 0..SPONGE_WIDTH {
-                result[r] = Self::mds_row_shf_circuit(builder, r, state);
-            }
-
-            result
+            core::array::from_fn(|r| Self::mds_row_shf_circuit(builder, r, state))
         }
     }
 

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -249,12 +249,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
 
     pub fn get_hash(&mut self, builder: &mut CircuitBuilder<F, D>) -> HashOutTarget {
         HashOutTarget {
-            elements: [
-                self.get_challenge(builder),
-                self.get_challenge(builder),
-                self.get_challenge(builder),
-                self.get_challenge(builder),
-            ],
+            elements: core::array::from_fn(|_| self.get_challenge(builder)),
         }
     }
 
@@ -262,7 +257,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         &mut self,
         builder: &mut CircuitBuilder<F, D>,
     ) -> ExtensionTarget<D> {
-        self.get_n_challenges(builder, D).try_into().unwrap()
+        ExtensionTarget(core::array::from_fn(|_| self.get_challenge(builder)))
     }
 
     /// Absorb any buffered inputs. After calling this, the input buffer will be empty, and the

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -191,9 +191,7 @@ pub trait Witness<F: Field>: WitnessWrite<F> {
     where
         F: RichField + Extendable<D>,
     {
-        F::Extension::from_basefield_array(
-            self.get_targets(&et.to_target_array()).try_into().unwrap(),
-        )
+        F::Extension::from_basefield_array(et.to_target_array().map(|t| self.get_target(t)))
     }
 
     fn get_extension_targets<const D: usize>(&self, ets: &[ExtensionTarget<D>]) -> Vec<F::Extension>
@@ -218,7 +216,7 @@ pub trait Witness<F: Field>: WitnessWrite<F> {
 
     fn get_hash_target(&self, ht: HashOutTarget) -> HashOut<F> {
         HashOut {
-            elements: self.get_targets(&ht.elements).try_into().unwrap(),
+            elements: ht.elements.map(|t| self.get_target(t)),
         }
     }
 

--- a/plonky2/src/lib.rs
+++ b/plonky2/src/lib.rs
@@ -3,6 +3,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(slice_as_chunks)]
+#![feature(array_chunks)]
+#![feature(array_try_from_fn)]
 
 #[cfg(not(feature = "std"))]
 pub extern crate alloc;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -356,13 +356,11 @@ mod tests {
         )?;
 
         // Verify that the proof correctly computes a repeated hash.
-        let initial_hash = &proof.public_inputs[..4];
+        let initial_hash = *proof.public_inputs.first_chunk().unwrap();
         let hash = &proof.public_inputs[4..8];
         let counter = proof.public_inputs[8];
-        let expected_hash: [F; 4] = iterate_poseidon(
-            initial_hash.try_into().unwrap(),
-            counter.to_canonical_u64() as usize,
-        );
+        let expected_hash: [F; 4] =
+            iterate_poseidon(initial_hash, counter.to_canonical_u64() as usize);
         assert_eq!(hash, expected_hash);
 
         cyclic_circuit_data.verify(proof)

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -228,10 +228,7 @@ pub trait Read {
     /// Reads an array of Target from `self`.
     #[inline]
     fn read_target_array<const N: usize>(&mut self) -> IoResult<[Target; N]> {
-        (0..N)
-            .map(|_| self.read_target())
-            .collect::<Result<Vec<_>, _>>()
-            .map(|v| v.try_into().unwrap())
+        core::array::try_from_fn(|_| self.read_target())
     }
 
     /// Reads a vector of Target from `self`.


### PR DESCRIPTION
Use the following array tools to avoid allocations and `try_into` calls:

- `core::array::from_fn`
- `[T]::first_chunk`
- `[T]::array_chunks`
- `[T; N]::map`
- `iter_fixed::IntoIteratorFixed`

The `try_into` calls are more of a nit that sometimes look like allocations, so I figured might as well get rid of em now that some of the chunk stuff is stable.