### PR TITLE
Relax restriction to a single looked table for CTL

### DIFF
--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -556,6 +556,16 @@ pub trait PrimeField64: PrimeField + Field64 {
 
     fn to_noncanonical_u64(&self) -> u64;
 
+    /// The conversion to a canonical i64 is mostly useful for debugging,
+    /// as it tries to recover 'negative' values for better readability.
+    fn to_canonical_i64(&self) -> i64 {
+        i64::try_from(self.to_canonical_u64()).unwrap_or_else(|_| {
+            i64::try_from(self.neg().to_canonical_u64())
+                .expect("This conversion should never fail.")
+                .neg()
+        })
+    }
+
     #[inline(always)]
     fn to_canonical(&self) -> Self {
         Self::from_canonical_u64(self.to_canonical_u64())

--- a/starky/src/lookup.rs
+++ b/starky/src/lookup.rs
@@ -6,6 +6,7 @@ use alloc::{vec, vec::Vec};
 use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::iter::repeat;
+use core::ops::Neg;
 
 use itertools::Itertools;
 use num_bigint::BigUint;
@@ -44,6 +45,21 @@ impl<F: Field> Default for Filter<F> {
         Self {
             products: vec![],
             constants: vec![Column::constant(F::ONE)],
+        }
+    }
+}
+
+impl<F: Field> Neg for Filter<F> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self {
+            products: self
+                .products
+                .into_iter()
+                .map(|(c1, c2)| (c1, -c2))
+                .collect(),
+            constants: self.constants.into_iter().map(|c| -c).collect(),
         }
     }
 }
@@ -137,6 +153,26 @@ pub struct Column<F: Field> {
     linear_combination: Vec<(usize, F)>,
     next_row_linear_combination: Vec<(usize, F)>,
     constant: F,
+}
+
+impl<F: Field> Neg for Column<F> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self {
+            linear_combination: self
+                .linear_combination
+                .into_iter()
+                .map(|(c, f)| (c, -f))
+                .collect(),
+            next_row_linear_combination: self
+                .next_row_linear_combination
+                .into_iter()
+                .map(|(c, f)| (c, -f))
+                .collect(),
+            constant: -self.constant,
+        }
+    }
 }
 
 impl<F: Field> Column<F> {


### PR DESCRIPTION
In our use of plonky2, we have a few instances where we need both several looked and several looking tables.  Think of these lookups as many-to-many multiplexers, or a kind of bus.  Looking tables can be thought of as pushing values with an obligation to process them onto the bus, looked tables can be seen as pulling values to discharge that obligation.

My first attempt changed from `looked_table` to `looked_tables`, but then I noticed that thanks to logup, we don't need this complication: looked_tables are just looking_tables with negative multiplicities.

Thus we can get a simpler system by just removing `looked_table` completely, and giving people tools to negate the multiplicities of their lookup tables.

We also preserve the old `CrossTableLookup::new`, which applies the negation to the passed `looked_table` automatically to keep the API as compatible as possible.

This PR only touches cross table lookups.  We could do the same for the intra-table lookups in `starky/src/lookup.rs`.  But that's for a separate PR.

This is a port of https://github.com/0xPolygonZero/plonky2/pull/1575