### PR TITLE
fix: remove clippy unexpected_cfgs warning

### DIFF
--- a/maybe_rayon/src/lib.rs
+++ b/maybe_rayon/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(std), no_std)]
+#![no_std]
 
 #[cfg(not(feature = "parallel"))]
 extern crate alloc;


### PR DESCRIPTION
Since `std` doesn't exist as a cfg, `not(std)` was always true, so this does not change any behavior.